### PR TITLE
Fix/sort meetings

### DIFF
--- a/src/utils/meetingSort.js
+++ b/src/utils/meetingSort.js
@@ -119,6 +119,12 @@ export const getSortedMeetingInfo = (input, startTime, endTime, minCellCount) =>
         }
     }
 
-    result.schedules.sort((a, b) => a.date.localeCompare(b.date));
+    result.schedules.sort((a, b) => {
+        const parseDate = (dateString) => {
+            const [year, month, day] = dateString.match(/(\d+)/g);
+            return new Date(year, month - 1, day);
+        }
+        return parseDate(a.date) - parseDate(b.date);
+    });
     return result;
 };


### PR DESCRIPTION
- `getSortedMeetingInfo`의 결과를 날짜 순으로 정렬할 때 ascii 순으로 정렬되는 문제를 수정